### PR TITLE
Improve type safety (closes #60)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/jest": "^29.5.6",
     "@typescript-eslint/eslint-plugin": "^6.8.0",
     "@typescript-eslint/parser": "^6.8.0",
-    "concurrently": "^8.2.1",
+    "concurrently": "^8.2.2",
     "coveralls": "^3.1.1",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",

--- a/packages/nukak-browser/package.json
+++ b/packages/nukak-browser/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "bunchee": "^3.9.0",
-    "concurrently": "^8.2.1",
+    "concurrently": "^8.2.2",
     "copyfiles": "^2.4.1",
     "nukak": "^0.3.1",
     "rimraf": "^5.0.5",

--- a/packages/nukak-browser/src/querier/genericClientRepository.ts
+++ b/packages/nukak-browser/src/querier/genericClientRepository.ts
@@ -7,19 +7,19 @@ export class GenericClientRepository<E> implements ClientRepository<E> {
     readonly querier: ClientQuerier,
   ) {}
 
-  findOneById<P extends QueryProject<E>>(id: IdValue<E>, project?: P, opts?: RequestOptions) {
+  findOneById(id: IdValue<E>, project?: QueryProject<E>, opts?: RequestOptions) {
     return this.querier.findOneById(this.entity, id, project, opts);
   }
 
-  findOne<P extends QueryProject<E>>(qm: QueryOne<E>, project?: P, opts?: RequestOptions) {
+  findOne(qm: QueryOne<E>, project?: QueryProject<E>, opts?: RequestOptions) {
     return this.querier.findOne(this.entity, qm, project, opts);
   }
 
-  findMany<P extends QueryProject<E>>(qm: QueryCriteria<E>, project?: P, opts?: RequestOptions) {
+  findMany(qm: QueryCriteria<E>, project?: QueryProject<E>, opts?: RequestOptions) {
     return this.querier.findMany(this.entity, qm, project, opts);
   }
 
-  findManyAndCount<P extends QueryProject<E>>(qm: QueryCriteria<E>, project?: P, opts?: RequestOptions) {
+  findManyAndCount(qm: QueryCriteria<E>, project?: QueryProject<E>, opts?: RequestOptions) {
     return this.querier.findManyAndCount(this.entity, qm, project, opts);
   }
 

--- a/packages/nukak-browser/src/querier/httpQuerier.ts
+++ b/packages/nukak-browser/src/querier/httpQuerier.ts
@@ -1,7 +1,6 @@
 import { getMeta } from 'nukak/entity';
 import type {
   IdValue,
-  Merge,
   Query,
   QueryCriteria,
   QueryOne,
@@ -19,41 +18,31 @@ import { GenericClientRepository } from './genericClientRepository.js';
 export class HttpQuerier implements ClientQuerier {
   constructor(readonly basePath: string) {}
 
-  findOneById<E, P extends QueryProject<E>>(entity: Type<E>, id: IdValue<E>, project?: P, opts?: RequestOptions) {
+  findOneById<E>(entity: Type<E>, id: IdValue<E>, project?: QueryProject<E>, opts?: RequestOptions) {
     const qm = { $project: project } satisfies Query<E>;
     const basePath = this.getBasePath(entity);
     const qs = stringifyQuery(qm);
-    return get<Merge<E, P>>(`${basePath}/${id}${qs}`, opts);
+    return get<E>(`${basePath}/${id}${qs}`, opts);
   }
 
-  findOne<E, P extends QueryProject<E>>(entity: Type<E>, qm: QueryOne<E>, project?: P, opts?: RequestOptions) {
+  findOne<E>(entity: Type<E>, qm: QueryOne<E>, project?: QueryProject<E>, opts?: RequestOptions) {
     const q = { ...qm, $project: project } satisfies Query<E>;
     const basePath = this.getBasePath(entity);
     const qs = stringifyQuery(q);
-    return get<Merge<E, P>>(`${basePath}/one${qs}`, opts);
+    return get<E>(`${basePath}/one${qs}`, opts);
   }
 
-  findMany<E, P extends QueryProject<E>>(
-    entity: Type<E>,
-    qm: QueryCriteria<E>,
-    project?: P,
-    opts?: RequestFindOptions,
-  ) {
+  findMany<E>(entity: Type<E>, qm: QueryCriteria<E>, project?: QueryProject<E>, opts?: RequestFindOptions) {
     const data: Query<E> & Pick<typeof opts, 'count'> = { ...qm, $project: project };
     if (opts?.count) {
       data.count = true;
     }
     const basePath = this.getBasePath(entity);
     const qs = stringifyQuery(data);
-    return get<Merge<E, P>[]>(`${basePath}${qs}`, opts);
+    return get<E[]>(`${basePath}${qs}`, opts);
   }
 
-  findManyAndCount<E, P extends QueryProject<E>>(
-    entity: Type<E>,
-    qm: QueryCriteria<E>,
-    project?: P,
-    opts?: RequestFindOptions,
-  ) {
+  findManyAndCount<E>(entity: Type<E>, qm: QueryCriteria<E>, project?: QueryProject<E>, opts?: RequestFindOptions) {
     return this.findMany(entity, qm, project, { ...opts, count: true });
   }
 

--- a/packages/nukak-browser/src/querier/querier.util.spec.ts
+++ b/packages/nukak-browser/src/querier/querier.util.spec.ts
@@ -24,12 +24,11 @@ it('stringifyQuery', () => {
   const source: Query<Item> = {
     $project: { id: 1, name: 1, tax: true, measureUnit: { $project: { id: 1, name: 1, categoryId: 1 } } },
     $filter: { name: 'Batman', companyId: 38 },
-    $group: ['companyId'],
     $sort: { companyId: 1, name: -1 },
     $limit: 5,
   };
   const result = stringifyQuery(source);
   const expected =
-    '?$project={"id":1,"name":1,"tax":true,"measureUnit":{"$project":{"id":1,"name":1,"categoryId":1}}}&$filter={"name":"Batman","companyId":38}&$group=["companyId"]&$sort={"companyId":1,"name":-1}&$limit=5';
+    '?$project={"id":1,"name":1,"tax":true,"measureUnit":{"$project":{"id":1,"name":1,"categoryId":1}}}&$filter={"name":"Batman","companyId":38}&$sort={"companyId":1,"name":-1}&$limit=5';
   expect(result).toBe(expected);
 });

--- a/packages/nukak-browser/src/type/clientQuerier.ts
+++ b/packages/nukak-browser/src/type/clientQuerier.ts
@@ -4,7 +4,6 @@ import type {
   QueryOptions,
   IdValue,
   QueryProject,
-  Merge,
   QueryOne,
   QuerySearch,
   QueryCriteria,
@@ -13,33 +12,33 @@ import type { ClientRepository } from './clientRepository.js';
 import type { RequestOptions, RequestSuccessResponse } from './request.js';
 
 export interface ClientQuerier extends UniversalQuerier {
-  findOneById<E, P extends QueryProject<E>>(
+  findOneById<E>(
     entity: Type<E>,
     id: IdValue<E>,
-    project?: P,
+    project?: QueryProject<E>,
     opts?: RequestOptions,
-  ): Promise<RequestSuccessResponse<Merge<E, P>>>;
+  ): Promise<RequestSuccessResponse<E>>;
 
-  findOne<E, P extends QueryProject<E>>(
+  findOne<E>(
     entity: Type<E>,
     qm: QueryOne<E>,
-    project?: P,
+    project?: QueryProject<E>,
     opts?: RequestOptions,
-  ): Promise<RequestSuccessResponse<Merge<E, P>>>;
+  ): Promise<RequestSuccessResponse<E>>;
 
-  findMany<E, P extends QueryProject<E>>(
+  findMany<E>(
     entity: Type<E>,
     qm: QueryCriteria<E>,
-    project?: P,
+    project?: QueryProject<E>,
     opts?: RequestOptions,
-  ): Promise<RequestSuccessResponse<Merge<E, P>[]>>;
+  ): Promise<RequestSuccessResponse<E[]>>;
 
-  findManyAndCount<E, P extends QueryProject<E>>(
+  findManyAndCount<E>(
     entity: Type<E>,
     qm: QueryCriteria<E>,
-    project?: P,
+    project?: QueryProject<E>,
     opts?: RequestOptions,
-  ): Promise<RequestSuccessResponse<Merge<E, P>[]>>;
+  ): Promise<RequestSuccessResponse<E[]>>;
 
   count<E>(entity: Type<E>, qm?: QuerySearch<E>, opts?: RequestOptions): Promise<RequestSuccessResponse<number>>;
 

--- a/packages/nukak-browser/src/type/clientRepository.ts
+++ b/packages/nukak-browser/src/type/clientRepository.ts
@@ -3,7 +3,6 @@ import type {
   QueryOptions,
   IdValue,
   QueryProject,
-  Merge,
   QuerySearch,
   QueryCriteria,
   QueryOneCriteria,
@@ -11,29 +10,25 @@ import type {
 import type { RequestOptions, RequestSuccessResponse } from './request.js';
 
 export interface ClientRepository<E> extends UniversalRepository<E> {
-  findOneById<P extends QueryProject<E>>(
-    id: IdValue<E>,
-    project?: P,
-    opts?: RequestOptions,
-  ): Promise<RequestSuccessResponse<Merge<E, P>>>;
+  findOneById(id: IdValue<E>, project?: QueryProject<E>, opts?: RequestOptions): Promise<RequestSuccessResponse<E>>;
 
-  findOne<P extends QueryProject<E>>(
+  findOne(
     qm: QueryOneCriteria<E>,
-    project?: P,
+    project?: QueryProject<E>,
     opts?: RequestOptions,
-  ): Promise<RequestSuccessResponse<Merge<E, P>>>;
+  ): Promise<RequestSuccessResponse<E>>;
 
-  findMany<P extends QueryProject<E>>(
+  findMany(
     qm: QueryCriteria<E>,
-    project?: P,
+    project?: QueryProject<E>,
     opts?: RequestOptions,
-  ): Promise<RequestSuccessResponse<Merge<E, P>[]>>;
+  ): Promise<RequestSuccessResponse<E[]>>;
 
-  findManyAndCount<P extends QueryProject<E>>(
+  findManyAndCount(
     qm: QueryCriteria<E>,
-    project?: P,
+    project?: QueryProject<E>,
     opts?: RequestOptions,
-  ): Promise<RequestSuccessResponse<Merge<E, P>[]>>;
+  ): Promise<RequestSuccessResponse<E[]>>;
 
   count(qm?: QuerySearch<E>, opts?: RequestOptions): Promise<RequestSuccessResponse<number>>;
 

--- a/packages/nukak-express/src/query.util.spec.ts
+++ b/packages/nukak-express/src/query.util.spec.ts
@@ -1,5 +1,5 @@
 import type { Request } from 'express';
-import type { Query, QueryFilter, QueryStringified } from 'nukak/type';
+import type { Query, QueryStringified } from 'nukak/type';
 import { Item } from 'nukak/test';
 import { parseQuery } from './query.util.js';
 
@@ -17,8 +17,6 @@ it('parseQuery stringified', () => {
     $project:
       '{ "id": true, "name": true, "measureUnit": {"$project":{"id":true, "name":true}}, "tax": {"$project":{"id":true, "name":true}} }',
     $filter: '{ "name": "lorem", "companyId": 40 }',
-    $group: '["companyId"]',
-    $having: '{ "count": {"$gte": 10} }',
     $sort: '{ "name": -1, "companyId": 1 }',
     $skip: '200',
     $limit: '100',
@@ -31,8 +29,6 @@ it('parseQuery stringified', () => {
       tax: { $project: { id: true, name: true } },
     },
     $filter: { name: 'lorem', companyId: 40 },
-    $group: ['companyId'],
-    $having: { count: { $gte: 10 } } as QueryFilter<Item>,
     $sort: { name: -1, companyId: 1 },
     $skip: 200,
     $limit: 100,

--- a/packages/nukak-express/src/query.util.ts
+++ b/packages/nukak-express/src/query.util.ts
@@ -9,12 +9,6 @@ export function parseQuery(req: Request) {
     qm.$project = JSON.parse(qmsSrc.$project);
   }
   qm.$filter = qmsSrc.$filter ? JSON.parse(qmsSrc.$filter) : {};
-  if (qmsSrc.$group) {
-    qm.$group = JSON.parse(qmsSrc.$group);
-  }
-  if (qmsSrc.$having) {
-    qm.$having = JSON.parse(qmsSrc.$having);
-  }
   if (qmsSrc.$sort) {
     qm.$sort = JSON.parse(qmsSrc.$sort);
   }

--- a/packages/nukak-maria/src/mariaDialect.ts
+++ b/packages/nukak-maria/src/mariaDialect.ts
@@ -1,13 +1,9 @@
 import sqlstring from 'sqlstring';
 import { AbstractSqlDialect } from 'nukak/dialect';
-import { QueryRaw, Scalar } from 'nukak/type';
-import { getRawValue } from 'nukak/util';
+import { Scalar } from 'nukak/type';
 
 export class MariaDialect extends AbstractSqlDialect {
   override escape(value: any): Scalar {
-    if (value instanceof QueryRaw) {
-      return getRawValue({ value, dialect: this });
-    }
     return sqlstring.escape(value);
   }
 }

--- a/packages/nukak-mongo/src/mongoDialect.ts
+++ b/packages/nukak-mongo/src/mongoDialect.ts
@@ -61,10 +61,10 @@ export class MongoDialect {
     return buildSortMap(sort) as Sort;
   }
 
-  aggregationPipeline<E extends Document, P extends QueryProject<E>>(
+  aggregationPipeline<E extends Document>(
     entity: Type<E>,
     qm: QueryCriteria<E>,
-    project?: P,
+    project?: QueryProject<E>,
   ): MongoAggregationPipelineEntry<E>[] {
     const meta = getMeta(entity);
 

--- a/packages/nukak-mongo/src/mongodbQuerier.ts
+++ b/packages/nukak-mongo/src/mongodbQuerier.ts
@@ -27,16 +27,14 @@ export class MongodbQuerier extends AbstractQuerier {
   override async findMany<E extends Document>(entity: Type<E>, qm: QueryCriteria<E>, project?: QueryProject<E>) {
     const meta = getMeta(entity);
 
-    type D = E;
-
-    let documents: D[];
+    let documents: E[];
     const hasProjectRelations = isProjectingRelations(meta, project);
 
     if (hasProjectRelations) {
       const pipeline = this.dialect.aggregationPipeline(entity, qm, project);
       this.extra?.logger('findMany', entity.name, JSON.stringify(pipeline, null, 2));
-      documents = await this.collection(entity).aggregate<D>(pipeline, { session: this.session }).toArray();
-      documents = this.dialect.normalizeIds(meta, documents) as D[];
+      documents = await this.collection(entity).aggregate<E>(pipeline, { session: this.session }).toArray();
+      documents = this.dialect.normalizeIds(meta, documents) as E[];
       await this.findToManyRelations(entity, documents, project);
     } else {
       const cursor = this.collection(entity).find<E>({}, { session: this.session });
@@ -62,8 +60,8 @@ export class MongodbQuerier extends AbstractQuerier {
 
       this.extra?.logger?.('findMany', entity.name, qm, project);
 
-      documents = (await cursor.toArray()) as D[];
-      documents = this.dialect.normalizeIds(meta, documents) as D[];
+      documents = (await cursor.toArray()) as E[];
+      documents = this.dialect.normalizeIds(meta, documents) as E[];
     }
 
     return documents;

--- a/packages/nukak-mongo/src/mongodbQuerier.ts
+++ b/packages/nukak-mongo/src/mongodbQuerier.ts
@@ -9,16 +9,7 @@ import {
   hasKeys,
   isProjectingRelations,
 } from 'nukak/util';
-import type {
-  Type,
-  QueryOptions,
-  IdValue,
-  ExtraOptions,
-  QueryProject,
-  Merge,
-  QuerySearch,
-  QueryCriteria,
-} from 'nukak/type';
+import type { Type, QueryOptions, IdValue, ExtraOptions, QueryProject, QuerySearch, QueryCriteria } from 'nukak/type';
 
 import { MongoDialect } from './mongoDialect.js';
 
@@ -33,14 +24,10 @@ export class MongodbQuerier extends AbstractQuerier {
     super();
   }
 
-  override async findMany<E extends Document, P extends QueryProject<E>>(
-    entity: Type<E>,
-    qm: QueryCriteria<E>,
-    project?: P,
-  ) {
+  override async findMany<E extends Document>(entity: Type<E>, qm: QueryCriteria<E>, project?: QueryProject<E>) {
     const meta = getMeta(entity);
 
-    type D = Merge<E, P>;
+    type D = E;
 
     let documents: D[];
     const hasProjectRelations = isProjectingRelations(meta, project);

--- a/packages/nukak-mysql/src/mysqlDialect.ts
+++ b/packages/nukak-mysql/src/mysqlDialect.ts
@@ -1,13 +1,9 @@
 import sqlstring from 'sqlstring';
 import { AbstractSqlDialect } from 'nukak/dialect';
-import { QueryRaw, Scalar } from 'nukak/type';
-import { getRawValue } from 'nukak/util';
+import { Scalar } from 'nukak/type';
 
 export class MySqlDialect extends AbstractSqlDialect {
   override escape(value: any): Scalar {
-    if (value instanceof QueryRaw) {
-      return getRawValue({ value, dialect: this });
-    }
     return sqlstring.escape(value);
   }
 }

--- a/packages/nukak-postgres/src/postgresDialect.ts
+++ b/packages/nukak-postgres/src/postgresDialect.ts
@@ -7,12 +7,10 @@ import {
   Type,
   FieldKey,
   Scalar,
-  QueryRaw,
 } from 'nukak/type';
 import { AbstractSqlDialect } from 'nukak/dialect';
 import { getMeta } from 'nukak/entity';
 import { quoteLiteral } from 'node-pg-format';
-import { getRawValue } from 'nukak/util';
 
 export class PostgresDialect extends AbstractSqlDialect {
   constructor() {
@@ -68,9 +66,6 @@ export class PostgresDialect extends AbstractSqlDialect {
   }
 
   override escape(value: any): Scalar {
-    if (value instanceof QueryRaw) {
-      return getRawValue({ value, dialect: this });
-    }
     return quoteLiteral(value);
   }
 }

--- a/packages/nukak-sqlite/src/sqliteDialect.ts
+++ b/packages/nukak-sqlite/src/sqliteDialect.ts
@@ -1,8 +1,7 @@
 import sqlstring from 'sqlstring-sqlite';
 import { getMeta } from 'nukak/entity';
-import { QueryFilterMap, QueryTextSearchOptions, Type, QueryComparisonOptions, QueryRaw, Scalar } from 'nukak/type';
+import { QueryFilterMap, QueryTextSearchOptions, Type, QueryComparisonOptions, Scalar } from 'nukak/type';
 import { AbstractSqlDialect } from 'nukak/dialect';
-import { getRawValue } from 'nukak/util';
 
 export class SqliteDialect extends AbstractSqlDialect {
   constructor() {
@@ -25,9 +24,6 @@ export class SqliteDialect extends AbstractSqlDialect {
   }
 
   override escape(value: any): Scalar {
-    if (value instanceof QueryRaw) {
-      return getRawValue({ value, dialect: this });
-    }
     return sqlstring.escape(value);
   }
 }

--- a/packages/nukak/src/dialect/abstractSqlDialect-spec.ts
+++ b/packages/nukak/src/dialect/abstractSqlDialect-spec.ts
@@ -159,13 +159,10 @@ export abstract class AbstractSqlDialectSpec implements Spec {
             id: 1,
             something: 1,
           } as any,
-          $group: ['id', 'something' as any],
         },
         ['id', 'something' as FieldKey<User>],
       ),
-    ).toBe(
-      'SELECT `id` FROM `User` WHERE `id` = 1 AND `something` = 1 GROUP BY `id`, `something` ORDER BY `id`, `something`',
-    );
+    ).toBe('SELECT `id` FROM `User` WHERE `id` = 1 AND `something` = 1 ORDER BY `id`, `something`');
 
     expect(
       this.dialect.insert(User, {
@@ -788,191 +785,6 @@ export abstract class AbstractSqlDialectSpec implements Spec {
     );
   }
 
-  shouldFind$group() {
-    expect(
-      this.dialect.find(User, {
-        $group: ['companyId'],
-      }),
-    ).toBe(
-      'SELECT `id`, `companyId`, `creatorId`, `createdAt`, `updatedAt`, `name`, `email`, `password` FROM `User` GROUP BY `companyId`',
-    );
-
-    expect(
-      this.dialect.find(
-        User,
-        {
-          $group: ['companyId'],
-          $having: {
-            count: {
-              $gte: 10,
-            },
-          } as QueryFilter<User>,
-        },
-        ['companyId', raw('COUNT(*)', 'count')],
-      ),
-    ).toBe('SELECT `companyId`, COUNT(*) `count` FROM `User` GROUP BY `companyId` HAVING `count` >= 10');
-
-    expect(
-      this.dialect.find(
-        User,
-        {
-          $filter: { companyId: 1 },
-          $group: ['companyId'],
-          $skip: 50,
-          $limit: 100,
-          $sort: { name: 'desc' },
-        },
-        ['id', 'name'],
-      ),
-    ).toBe(
-      'SELECT `id`, `name` FROM `User` WHERE `companyId` = 1 GROUP BY `companyId` ORDER BY `name` DESC LIMIT 100 OFFSET 50',
-    );
-  }
-
-  shouldProject$count() {
-    expect(
-      this.dialect.find(
-        User,
-        {
-          $group: ['companyId'],
-          $having: {
-            counting: {
-              $gte: 10,
-            },
-          } as QueryFilter<User>,
-        },
-        {
-          companyId: true,
-          counting: { $count: 1 },
-        },
-      ),
-    ).toBe('SELECT `companyId`, COUNT(*) `counting` FROM `User` GROUP BY `companyId` HAVING `counting` >= 10');
-  }
-
-  shouldProject$max() {
-    expect(
-      this.dialect.find(
-        User,
-        {
-          $group: ['companyId'],
-          $having: {
-            latest: {
-              $gte: 10,
-            },
-          } as QueryFilter<User>,
-        },
-        {
-          companyId: true,
-          latest: { $max: 'createdAt' },
-        },
-      ),
-    ).toBe('SELECT `companyId`, MAX(`createdAt`) `latest` FROM `User` GROUP BY `companyId` HAVING `latest` >= 10');
-  }
-
-  shouldProject$min() {
-    expect(
-      this.dialect.find(
-        User,
-        {
-          $group: ['companyId'],
-          $having: {
-            minimum: {
-              $gte: 10,
-            },
-          } as QueryFilter<User>,
-        },
-        {
-          companyId: true,
-          minimum: { $min: 'updatedAt' },
-        },
-      ),
-    ).toBe('SELECT `companyId`, MIN(`updatedAt`) `minimum` FROM `User` GROUP BY `companyId` HAVING `minimum` >= 10');
-  }
-
-  shouldProject$avg() {
-    expect(
-      this.dialect.find(
-        User,
-        {
-          $group: ['companyId'],
-          $having: {
-            average: {
-              $gte: 10,
-            },
-          } as QueryFilter<User>,
-        },
-        {
-          companyId: true,
-          average: { $avg: 'createdAt' },
-        },
-      ),
-    ).toBe('SELECT `companyId`, AVG(`createdAt`) `average` FROM `User` GROUP BY `companyId` HAVING `average` >= 10');
-  }
-
-  shouldProject$sum() {
-    expect(
-      this.dialect.find(
-        Item,
-        {
-          $group: ['creatorId'],
-          $having: {
-            total: {
-              $lt: 100,
-            },
-          },
-        },
-        {
-          creatorId: true,
-          total: { $sum: 'salePrice' },
-        },
-      ),
-    ).toBe('SELECT `creatorId`, SUM(`salePrice`) `total` FROM `Item` GROUP BY `creatorId` HAVING `total` < 100');
-
-    expect(
-      this.dialect.find(
-        Item,
-        {
-          $filter: { $or: [[1, 2], { code: 'abc' }] },
-          $group: ['creatorId'],
-          $having: {
-            total: {
-              $gte: 1000,
-            },
-          },
-        },
-        {
-          creatorId: true,
-          total: {
-            $sum: 'salePrice',
-          },
-        },
-      ),
-    ).toBe(
-      "SELECT `creatorId`, SUM(`salePrice`) `total` FROM `Item` WHERE `id` IN (1, 2) OR `code` = 'abc' GROUP BY `creatorId` HAVING `total` >= 1000",
-    );
-
-    // TODO support this
-    // expect(
-    //   this.dialect.find(ItemAdjustment, {
-    //     $project: {
-    //       item: {
-    //         $project: {
-    //           companyId: true,
-    //           total: {
-    //             $sum: 'salePrice',
-    //           },
-    //         },
-    //         $required: true,
-    //       },
-    //     },
-    //     $group: ['companyId'],
-    //   })
-    // ).toBe(
-    //   'SELECT `ItemAdjustment`.`id`, `item`.`id` `item.id`, `item`.`companyId` `item.companyId`, SUM(`item`.`salePrice`) `item.total`' +
-    //     ' FROM `ItemAdjustment` INNER JOIN `Item` `item` ON `item`.`id` = `ItemAdjustment`.`itemId` GROUP BY `companyId`'
-    // );
-  }
-
   shouldFind$limit() {
     expect(
       this.dialect.find(
@@ -1078,55 +890,6 @@ export abstract class AbstractSqlDialectSpec implements Spec {
   shouldFind$projectRaw() {
     expect(
       this.dialect.find(
-        Item,
-        {
-          $group: ['companyId'],
-        },
-        {
-          companyId: true,
-          total: raw(({ escapedPrefix, dialect }) => `SUM(${escapedPrefix}${dialect.escapeId('salePrice')})`),
-        },
-      ),
-    ).toBe('SELECT `companyId`, SUM(`salePrice`) `total` FROM `Item` GROUP BY `companyId`');
-
-    expect(
-      this.dialect.find(
-        ItemAdjustment,
-        {
-          $group: ['companyId'],
-        },
-        {
-          item: {
-            $project: {
-              companyId: true,
-              total: raw(({ escapedPrefix, dialect }) => `SUM(${escapedPrefix}${dialect.escapeId('salePrice')})`),
-            },
-            $required: true,
-          },
-        },
-      ),
-    ).toBe(
-      'SELECT `ItemAdjustment`.`id`, `item`.`id` `item.id`, `item`.`companyId` `item.companyId`, SUM(`item`.`salePrice`) `item.total`' +
-        ' FROM `ItemAdjustment` INNER JOIN `Item` `item` ON `item`.`id` = `ItemAdjustment`.`itemId` GROUP BY `companyId`',
-    );
-
-    expect(
-      this.dialect.find(
-        User,
-        {
-          $group: ['companyId'],
-          $having: {
-            count: {
-              $gte: 10,
-            },
-          } as QueryFilter<User>,
-        },
-        ['companyId', raw('COUNT(*)', 'count')],
-      ),
-    ).toBe('SELECT `companyId`, COUNT(*) `count` FROM `User` GROUP BY `companyId` HAVING `count` >= 10');
-
-    expect(
-      this.dialect.find(
         User,
         {
           $filter: { name: 'something' },
@@ -1154,11 +917,10 @@ export abstract class AbstractSqlDialectSpec implements Spec {
         Item,
         {
           $filter: { $and: [{ companyId: 1 }, raw('SUM(salePrice) > 500')] },
-          $group: ['creatorId'],
         },
         ['creatorId'],
       ),
-    ).toBe('SELECT `creatorId` FROM `Item` WHERE `companyId` = 1 AND SUM(salePrice) > 500 GROUP BY `creatorId`');
+    ).toBe('SELECT `creatorId` FROM `Item` WHERE `companyId` = 1 AND SUM(salePrice) > 500');
 
     expect(
       this.dialect.find(
@@ -1169,17 +931,6 @@ export abstract class AbstractSqlDialectSpec implements Spec {
         ['id'],
       ),
     ).toBe('SELECT `id` FROM `Item` WHERE `companyId` = 1 OR `id` = 5 OR SUM(salePrice) > 500');
-
-    expect(
-      this.dialect.find(
-        Item,
-        {
-          $filter: { $and: [raw('SUM(`salePrice`) > 500')] },
-          $group: ['companyId'],
-        },
-        ['id'],
-      ),
-    ).toBe('SELECT `id` FROM `Item` WHERE SUM(`salePrice`) > 500 GROUP BY `companyId`');
 
     expect(
       this.dialect.find(
@@ -1206,33 +957,30 @@ export abstract class AbstractSqlDialectSpec implements Spec {
         Item,
         {
           $filter: { $and: [raw('SUM(salePrice) > 500')] },
-          $group: ['creatorId'],
         },
         ['id'],
       ),
-    ).toBe('SELECT `id` FROM `Item` WHERE SUM(salePrice) > 500 GROUP BY `creatorId`');
+    ).toBe('SELECT `id` FROM `Item` WHERE SUM(salePrice) > 500');
 
     expect(
       this.dialect.find(
         Item,
         {
           $filter: raw('SUM(salePrice) > 500'),
-          $group: ['creatorId'],
         },
         ['id'],
       ),
-    ).toBe('SELECT `id` FROM `Item` WHERE SUM(salePrice) > 500 GROUP BY `creatorId`');
+    ).toBe('SELECT `id` FROM `Item` WHERE SUM(salePrice) > 500');
 
     expect(
       this.dialect.find(
         Item,
         {
           $filter: { $or: [[1, 2], { code: 'abc' }] },
-          $group: ['creatorId'],
         },
         ['creatorId'],
       ),
-    ).toBe("SELECT `creatorId` FROM `Item` WHERE `id` IN (1, 2) OR `code` = 'abc' GROUP BY `creatorId`");
+    ).toBe("SELECT `creatorId` FROM `Item` WHERE `id` IN (1, 2) OR `code` = 'abc'");
   }
 
   shouldFind$startsWith() {

--- a/packages/nukak/src/dialect/abstractSqlDialect.ts
+++ b/packages/nukak/src/dialect/abstractSqlDialect.ts
@@ -59,7 +59,7 @@ export abstract class AbstractSqlDialect implements QueryDialect {
     return where + sort + pager;
   }
 
-  projectFields<E>(entity: Type<E>, project: QueryProject<E>, opts: QueryProjectOptions = {}): string {
+  projectFields<E>(entity: Type<E>, project: QueryProject<E>, opts: QueryProjectOptions): string {
     const meta = getMeta(entity);
     const prefix = opts.prefix ? opts.prefix + '.' : '';
     const escapedPrefix = this.escapeId(opts.prefix, true, true);
@@ -185,7 +185,7 @@ export abstract class AbstractSqlDialect implements QueryDialect {
     return `SELECT ${fields}${relationFields} FROM ${this.escapeId(meta.name)}${tables}`;
   }
 
-  where<E>(entity: Type<E>, filter: QueryFilter<E> = {}, opts: QueryFilterOptions = {}): string {
+  where<E>(entity: Type<E>, filter: QueryFilter<E> = {}, opts: QueryFilterOptions): string {
     const meta = getMeta(entity);
     const { usePrecedence, clause = 'WHERE', softDelete } = opts;
 
@@ -358,16 +358,7 @@ export abstract class AbstractSqlDialect implements QueryDialect {
     return escapedPrefix + this.escapeId(field?.name ?? key);
   }
 
-  group<E>(entity: Type<E>, fields: readonly FieldKey<E>[]): string {
-    if (!fields?.length) {
-      return '';
-    }
-    const meta = getMeta(entity);
-    const names = fields.map((key) => this.escapeId(meta.fields[key]?.name ?? key)).join(', ');
-    return ` GROUP BY ${names}`;
-  }
-
-  sort<E>(entity: Type<E>, sort: QuerySort<E>, { prefix }: QueryOptions = {}): string {
+  sort<E>(entity: Type<E>, sort: QuerySort<E>, { prefix }: QueryOptions): string {
     const sortMap = buildSortMap(sort);
     if (!hasKeys(sortMap)) {
       return '';

--- a/packages/nukak/src/dialect/abstractSqlDialect.ts
+++ b/packages/nukak/src/dialect/abstractSqlDialect.ts
@@ -70,18 +70,9 @@ export abstract class AbstractSqlDialect implements QueryDialect {
       if (Array.isArray(project)) {
         projectArr = project;
       } else {
-        const projectPositive = getKeys(project).filter((it) => project[it]);
+        const projectPositive = getKeys(project).filter((it) => project[it]) as FieldKey<E>[];
         projectArr = projectPositive.length
-          ? projectPositive.map((it) => {
-              const val = project[it];
-              if (val instanceof QueryRaw) {
-                return raw(val.value, it);
-              }
-              if (!(it in meta.fields) && !(it in meta.relations)) {
-                throw new TypeError(`Unsupported operation: ${it}`);
-              }
-              return it as FieldKey<E>;
-            })
+          ? projectPositive
           : (getKeys(meta.fields).filter((it) => !(it in project)) as FieldKey<E>[]);
       }
       projectArr = projectArr.filter((it) => it instanceof QueryRaw || it in meta.fields);

--- a/packages/nukak/src/dialect/abstractSqlDialect.ts
+++ b/packages/nukak/src/dialect/abstractSqlDialect.ts
@@ -16,7 +16,7 @@ import {
   QueryFilterMap,
   QueryProjectOptions,
   QuerySortDirection,
-  QueryFilterLogical,
+  QueryFilterArray,
   QueryRaw,
   QuerySearch,
   QueryCriteria,
@@ -266,7 +266,7 @@ export abstract class AbstractSqlDialect implements QueryDialect {
       const op: '$and' | '$or' = negateOperatorMap[key as string] ?? key;
       const negate = key in negateOperatorMap ? 'NOT ' : '';
 
-      const values = val as QueryFilterLogical<E>;
+      const values = val as QueryFilterArray<E>;
       const hasManyItems = values.length > 1;
       const logicalComparison = values
         .map((filterEntry) => {

--- a/packages/nukak/src/dialect/abstractSqlDialect.ts
+++ b/packages/nukak/src/dialect/abstractSqlDialect.ts
@@ -50,12 +50,7 @@ export abstract class AbstractSqlDialect implements QueryDialect {
     this.escapeIdRegex = RegExp(escapeIdChar, 'g');
   }
 
-  criteria<E, P extends QueryProject<E>>(
-    entity: Type<E>,
-    qm: QueryCriteria<E>,
-    project: P,
-    opts: QueryOptions = {},
-  ): string {
+  criteria<E>(entity: Type<E>, qm: QueryCriteria<E>, project: QueryProject<E>, opts: QueryOptions = {}): string {
     const meta = getMeta(entity);
     const prefix = opts.prefix ?? (opts.autoPrefix || isProjectingRelations(meta, project)) ? meta.name : undefined;
     opts = { ...opts, prefix };
@@ -67,7 +62,7 @@ export abstract class AbstractSqlDialect implements QueryDialect {
     return where + group + having + sort + pager;
   }
 
-  projectFields<E, P extends QueryProject<E>>(entity: Type<E>, project: P, opts: QueryProjectOptions = {}): string {
+  projectFields<E>(entity: Type<E>, project: QueryProject<E>, opts: QueryProjectOptions = {}): string {
     const meta = getMeta(entity);
     const prefix = opts.prefix ? opts.prefix + '.' : '';
     const escapedPrefix = this.escapeId(opts.prefix, true, true);
@@ -456,7 +451,7 @@ export abstract class AbstractSqlDialect implements QueryDialect {
     return select + criteria;
   }
 
-  find<E, P extends QueryProject<E>>(entity: Type<E>, qm: QueryCriteria<E>, project?: P, opts?: QueryOptions): string {
+  find<E>(entity: Type<E>, qm: QueryCriteria<E>, project?: QueryProject<E>, opts?: QueryOptions): string {
     const select = this.select(entity, project, opts);
     const criteria = this.criteria(entity, qm, project, opts);
     return select + criteria;

--- a/packages/nukak/src/querier/abstractQuerier.ts
+++ b/packages/nukak/src/querier/abstractQuerier.ts
@@ -1,6 +1,5 @@
 import type {
   IdValue,
-  Merge,
   Querier,
   Query,
   QueryCriteria,
@@ -18,22 +17,18 @@ import { clone, getKeys, getProjectRelationKeys, getPersistableRelations } from 
 import { GenericRepository } from '../repository/index.js';
 
 export abstract class AbstractQuerier implements Querier {
-  findOneById<E, P extends QueryProject<E>>(entity: Type<E>, id: IdValue<E>, project?: P) {
+  findOneById<E>(entity: Type<E>, id: IdValue<E>, project?: QueryProject<E>) {
     return this.findOne(entity, { $filter: id }, project);
   }
 
-  async findOne<E, P extends QueryProject<E>>(entity: Type<E>, qm: QueryOneCriteria<E>, project?: P) {
+  async findOne<E>(entity: Type<E>, qm: QueryOneCriteria<E>, project?: QueryProject<E>) {
     const rows = await this.findMany(entity, { ...qm, $limit: 1 }, project);
     return rows[0];
   }
 
-  abstract findMany<E, P extends QueryProject<E>>(
-    entity: Type<E>,
-    qm: QueryCriteria<E>,
-    project?: P,
-  ): Promise<Merge<E, P>[]>;
+  abstract findMany<E>(entity: Type<E>, qm: QueryCriteria<E>, project?: QueryProject<E>): Promise<E[]>;
 
-  findManyAndCount<E, P extends QueryProject<E>>(entity: Type<E>, qm: QueryCriteria<E>, project?: P) {
+  findManyAndCount<E>(entity: Type<E>, qm: QueryCriteria<E>, project?: QueryProject<E>) {
     return Promise.all([this.findMany(entity, qm, project), this.count(entity, qm)]);
   }
 

--- a/packages/nukak/src/querier/abstractSqlQuerier.ts
+++ b/packages/nukak/src/querier/abstractSqlQuerier.ts
@@ -1,12 +1,4 @@
-import {
-  Type,
-  QueryOptions,
-  QueryUpdateResult,
-  QueryProject,
-  Merge,
-  QuerySearch,
-  QueryCriteria,
-} from '../type/index.js';
+import { Type, QueryOptions, QueryUpdateResult, QueryProject, QuerySearch, QueryCriteria } from '../type/index.js';
 import { unflatObjects, clone } from '../util/index.js';
 import { AbstractSqlDialect } from '../dialect/index.js';
 import { getMeta } from '../entity/index.js';
@@ -32,9 +24,9 @@ export abstract class AbstractSqlQuerier extends AbstractQuerier {
    */
   abstract run(query: string): Promise<QueryUpdateResult>;
 
-  override async findMany<E, P extends QueryProject<E>>(entity: Type<E>, qm: QueryCriteria<E>, project?: P) {
+  override async findMany<E>(entity: Type<E>, qm: QueryCriteria<E>, project?: QueryProject<E>) {
     const query = this.dialect.find(entity, qm, project);
-    const res = await this.all<Merge<E, P>>(query);
+    const res = await this.all<E>(query);
     const founds = unflatObjects(res);
     await this.findToManyRelations(entity, founds, project);
     return founds;

--- a/packages/nukak/src/repository/genericRepository.ts
+++ b/packages/nukak/src/repository/genericRepository.ts
@@ -16,19 +16,19 @@ export class GenericRepository<E> implements Repository<E> {
     readonly querier: Querier,
   ) {}
 
-  findOneById<P extends QueryProject<E>>(id: IdValue<E>, project?: P) {
+  findOneById(id: IdValue<E>, project?: QueryProject<E>) {
     return this.querier.findOneById(this.entity, id, project);
   }
 
-  findOne<P extends QueryProject<E>>(qm: QueryOneCriteria<E>, project?: P) {
+  findOne(qm: QueryOneCriteria<E>, project?: QueryProject<E>) {
     return this.querier.findOne(this.entity, qm, project);
   }
 
-  findMany<P extends QueryProject<E>>(qm: QueryCriteria<E>, project?: P) {
+  findMany(qm: QueryCriteria<E>, project?: QueryProject<E>) {
     return this.querier.findMany(this.entity, qm, project);
   }
 
-  findManyAndCount<P extends QueryProject<E>>(qm: QueryCriteria<E>, project?: P) {
+  findManyAndCount(qm: QueryCriteria<E>, project?: QueryProject<E>) {
     return this.querier.findManyAndCount(this.entity, qm, project);
   }
 

--- a/packages/nukak/src/test/entityMock.ts
+++ b/packages/nukak/src/test/entityMock.ts
@@ -250,9 +250,9 @@ export class Item extends BaseEntity {
   @Field({
     /**
      * `virtual` property allows defining the value for a non-persistent field,
-     * such value might be a scalar or a (`raw`) function. Virtual-fields can be
-     * used in `$project`, `$filter` and `$having` as a common field whose value
-     * is replaced at runtime.
+     * such value might be a scalar or a (`raw`) function. Virtual-fields can
+     * be used in `$project` and `$filter` as a common field whose value is
+     * replaced is replaced at runtime.
      */
     virtual: raw(({ escapedPrefix, dialect }) => {
       const query = dialect.count(
@@ -282,9 +282,9 @@ export class Tag extends BaseEntity {
     virtual: raw(({ escapedPrefix, dialect }) => {
       /**
        * `virtual` property allows defining the value for a non-persistent field,
-       * such value might be a scalar or a (`raw`) function. Virtual-fields can be
-       * used in `$project`, `$filter` and `$having` as a common field whose value
-       * is replaced at runtime.
+       * such value might be a scalar or a (`raw`) function. Virtual-fields can
+       * be used in `$project` and `$filter` as a common field whose value is
+       * replaced at runtime.
        */
       const query = dialect.count(
         ItemTag,

--- a/packages/nukak/src/type/querier.ts
+++ b/packages/nukak/src/type/querier.ts
@@ -1,5 +1,5 @@
 import type { Type } from './utility.js';
-import type { QueryCriteria, QueryOptions, QueryProject, QuerySearch, Merge, QueryOneCriteria } from './query.js';
+import type { QueryCriteria, QueryOptions, QueryProject, QuerySearch, QueryOneCriteria } from './query.js';
 import type { Repository } from './repository.js';
 import type { IdValue } from './entity.js';
 import type { UniversalQuerier } from './universalQuerier.js';
@@ -10,17 +10,13 @@ import type { UniversalQuerier } from './universalQuerier.js';
 export type IsolationLevel = 'read uncommitted' | 'read committed' | 'repeteable read' | 'serializable';
 
 export interface Querier extends UniversalQuerier {
-  findOneById<E, P extends QueryProject<E>>(entity: Type<E>, id: IdValue<E>, project?: P): Promise<Merge<E, P>>;
+  findOneById<E>(entity: Type<E>, id: IdValue<E>, project?: QueryProject<E>): Promise<E>;
 
-  findOne<E, P extends QueryProject<E>>(entity: Type<E>, qm: QueryOneCriteria<E>, project?: P): Promise<Merge<E, P>>;
+  findOne<E>(entity: Type<E>, qm: QueryOneCriteria<E>, project?: QueryProject<E>): Promise<E>;
 
-  findMany<E, P extends QueryProject<E>>(entity: Type<E>, qm: QueryCriteria<E>, project?: P): Promise<Merge<E, P>[]>;
+  findMany<E>(entity: Type<E>, qm: QueryCriteria<E>, project?: QueryProject<E>): Promise<E[]>;
 
-  findManyAndCount<E, P extends QueryProject<E>>(
-    entity: Type<E>,
-    qm: QueryCriteria<E>,
-    project?: P,
-  ): Promise<[Merge<E, P>[], number]>;
+  findManyAndCount<E>(entity: Type<E>, qm: QueryCriteria<E>, project?: QueryProject<E>): Promise<[E[], number]>;
 
   count<E>(entity: Type<E>, qm?: QuerySearch<E>): Promise<number>;
 

--- a/packages/nukak/src/type/query.ts
+++ b/packages/nukak/src/type/query.ts
@@ -432,7 +432,7 @@ export interface QueryDialect {
    * @param qm the criteria options
    * @param opts the query options
    */
-  find<E, P extends QueryProject<E>>(entity: Type<E>, qm: QueryCriteria<E>, project?: P, opts?: QueryOptions): string;
+  find<E>(entity: Type<E>, qm: QueryCriteria<E>, project?: QueryProject<E>, opts?: QueryOptions): string;
 
   /**
    * counts the number of records matching the given search parameters.
@@ -481,5 +481,3 @@ export interface QueryDialect {
    */
   escape(val: any): Scalar;
 }
-
-export type Merge<E, P> = E & (P extends string[] ? {} : { [K in Exclude<keyof P, keyof E>]: Scalar });

--- a/packages/nukak/src/type/query.ts
+++ b/packages/nukak/src/type/query.ts
@@ -28,36 +28,6 @@ export type QueryProjectOptions = {
 };
 
 /**
- * query projection of operations
- */
-export type QueryProjectOperation<E> = {
-  /**
-   * Calculates the quantity of entries
-   */
-  readonly $count?: FieldKey<E> | 1;
-
-  /**
-   * Gets the maximum value of a field in the entity
-   */
-  readonly $max?: FieldKey<E>;
-
-  /**
-   * Gets the minimum value of a field in the entity
-   */
-  readonly $min?: FieldKey<E>;
-
-  /**
-   * Gets the average value of a field in the entity
-   */
-  readonly $avg?: FieldKey<E>;
-
-  /**
-   * Sums up the specified values of all entries in the entity
-   */
-  readonly $sum?: FieldKey<E>;
-};
-
-/**
  * query projection as an array.
  */
 export type QueryProjectArray<E> = readonly (Key<E> | QueryRaw)[];
@@ -75,12 +45,9 @@ export type QueryProject<E> = QueryProjectArray<E> | QueryProjectMap<E>;
 /**
  * query projection of fields as a map.
  */
-export type QueryProjectFieldMap<E> =
-  | {
-      // TODO add support to use alias for projected fields (string value)
-      [K in FieldKey<E>]?: BooleanLike;
-    }
-  | { [K: string]: QueryProjectOperation<E> | QueryRaw };
+export type QueryProjectFieldMap<E> = {
+  [K in FieldKey<E>]?: BooleanLike;
+};
 
 /**
  * query projection of relations as a map.
@@ -307,16 +274,6 @@ export type QuerySearch<E> = {
    * filtering options.
    */
   $filter?: QueryFilter<E>;
-
-  /**
-   * list of fields to group.
-   */
-  $group?: readonly FieldKey<E>[];
-
-  /**
-   * having options.
-   */
-  $having?: QueryFilter<E>;
 } & QueryPager;
 
 /**

--- a/packages/nukak/src/type/query.ts
+++ b/packages/nukak/src/type/query.ts
@@ -46,14 +46,14 @@ export type QueryProject<E> = QueryProjectArray<E> | QueryProjectMap<E>;
  * query projection of fields as a map.
  */
 export type QueryProjectFieldMap<E> = {
-  [K in FieldKey<E>]?: BooleanLike;
+  readonly [K in FieldKey<E>]?: BooleanLike;
 };
 
 /**
  * query projection of relations as a map.
  */
 export type QueryProjectRelationMap<E> = {
-  [K in RelationKey<E>]?: BooleanLike | readonly Key<Unpacked<E[K]>>[] | QueryProjectRelationOptions<E[K]>;
+  readonly [K in RelationKey<E>]?: BooleanLike | readonly Key<Unpacked<E[K]>>[] | QueryProjectRelationOptions<E[K]>;
 };
 
 /**
@@ -78,16 +78,9 @@ export type QueryTextSearchOptions<E> = {
 };
 
 /**
- * value for a logical filtering.
- */
-export type QueryFilterLogical<E> = readonly QueryFilter<E>[];
-
-/**
  * comparison by fields.
  */
-export type QueryFilterFieldMap<E> =
-  | { readonly [K in FieldKey<E>]?: QueryFilterFieldValue<E[K]> }
-  | { readonly [K: string]: QueryFilterFieldValue<E[any]> };
+export type QueryFilterFieldMap<E> = { readonly [K in FieldKey<E>]?: QueryFilterFieldValue<E[K]> };
 
 /**
  * complex operators.
@@ -98,19 +91,19 @@ export type QueryFilterRootOperator<E> = {
   /**
    * joins query clauses with a logical `AND`, returns records that match all the clauses.
    */
-  readonly $and?: QueryFilterLogical<E>;
+  readonly $and?: QueryFilterArray<E>;
   /**
    * joins query clauses with a logical `OR`, returns records that match any of the clauses.
    */
-  readonly $or?: QueryFilterLogical<E>;
+  readonly $or?: QueryFilterArray<E>;
   /**
    * joins query clauses with a logical `AND`, returns records that do not match all the clauses.
    */
-  readonly $not?: QueryFilterLogical<E>;
+  readonly $not?: QueryFilterArray<E>;
   /**
    * joins query clauses with a logical `OR`, returns records that do not match any of the clauses.
    */
-  readonly $nor?: QueryFilterLogical<E>;
+  readonly $nor?: QueryFilterArray<E>;
   /**
    * whether the specified fields match against a full-text search of the given string.
    */
@@ -206,9 +199,19 @@ export type QueryFilterFieldOperatorMap<T> = {
 export type QueryFilterFieldValue<T> = T | readonly T[] | QueryFilterFieldOperatorMap<T> | QueryRaw;
 
 /**
+ * query single filter.
+ */
+export type QueryFilterSingle<E> = IdValue<E> | readonly IdValue<E>[] | QueryFilterMap<E> | QueryRaw;
+
+/**
+ * query filter array.
+ */
+export type QueryFilterArray<E> = readonly QueryFilterSingle<E>[];
+
+/**
  * query filter.
  */
-export type QueryFilter<E> = IdValue<E> | readonly IdValue<E>[] | QueryRaw | QueryFilterMap<E>;
+export type QueryFilter<E> = QueryFilterSingle<E> | QueryFilterArray<E>;
 
 /**
  * direction for the sort.
@@ -228,17 +231,15 @@ export type QuerySortObjects<E> = readonly { readonly field: FieldKey<E>; readon
 /**
  * sort by fields.
  */
-export type QuerySortFieldMap<E> =
-  | {
-      [K in FieldKey<E>]?: QuerySortDirection;
-    }
-  | { [K: string]: QuerySortDirection };
+export type QuerySortFieldMap<E> = {
+  readonly [K in FieldKey<E>]?: QuerySortDirection;
+};
 
 /**
  * sort by relations fields.
  */
 export type QuerySortRelationMap<E> = {
-  [K in RelationKey<E>]?: QuerySortMap<Unpacked<E[K]>>;
+  readonly [K in RelationKey<E>]?: QuerySortMap<Unpacked<E[K]>>;
 };
 
 /**

--- a/packages/nukak/src/type/repository.ts
+++ b/packages/nukak/src/type/repository.ts
@@ -1,5 +1,5 @@
 import type { IdValue } from './entity.js';
-import type { QueryCriteria, QueryOptions, QueryProject, QuerySearch, Merge, QueryOneCriteria } from './query.js';
+import type { QueryCriteria, QueryOptions, QueryProject, QuerySearch, QueryOneCriteria } from './query.js';
 import type { UniversalQuerier } from './universalQuerier.js';
 import type { Type } from './utility.js';
 
@@ -22,26 +22,26 @@ export type UniversalRepository<E> = {
    * @param id the primary key value
    * @param qm the criteria options
    */
-  findOneById<P extends QueryProject<E>>(id: IdValue<E>, project?: P): Promise<any>;
+  findOneById(id: IdValue<E>, project?: QueryProject<E>): Promise<any>;
 
   /**
    * obtains the first record matching the given search parameters.
    * @param qm the criteria options
    */
-  findOne<P extends QueryProject<E>>(qm: QueryOneCriteria<E>, project?: P): Promise<any>;
+  findOne(qm: QueryOneCriteria<E>, project?: QueryProject<E>): Promise<any>;
 
   /**
    * obtains the records matching the given search parameters.
    * @param qm the criteria options
    */
-  findMany<P extends QueryProject<E>>(qm: QueryCriteria<E>, project?: P): Promise<any>;
+  findMany(qm: QueryCriteria<E>, project?: QueryProject<E>): Promise<any>;
 
   /**
    * obtains the records matching the given search parameters,
    * also counts the number of matches ignoring pagination.
    * @param qm the criteria options
    */
-  findManyAndCount<P extends QueryProject<E>>(qm: QueryCriteria<E>, project?: P): Promise<any>;
+  findManyAndCount(qm: QueryCriteria<E>, project?: QueryProject<E>): Promise<any>;
 
   /**
    * counts the number of records matching the given search parameters.
@@ -105,13 +105,13 @@ export type UniversalRepository<E> = {
  * base contract for the backend repositories.
  */
 export interface Repository<E> extends UniversalRepository<E> {
-  findOneById<P extends QueryProject<E>>(id: IdValue<E>, project?: P): Promise<Merge<E, P>>;
+  findOneById(id: IdValue<E>, project?: QueryProject<E>): Promise<E>;
 
-  findOne<P extends QueryProject<E>>(qm: QueryOneCriteria<E>, project?: P): Promise<Merge<E, P>>;
+  findOne(qm: QueryOneCriteria<E>, project?: QueryProject<E>): Promise<E>;
 
-  findMany<P extends QueryProject<E>>(qm: QueryCriteria<E>, project?: P): Promise<Merge<E, P>[]>;
+  findMany(qm: QueryCriteria<E>, project?: QueryProject<E>): Promise<E[]>;
 
-  findManyAndCount<P extends QueryProject<E>>(qm: QueryCriteria<E>, project?: P): Promise<[Merge<E, P>[], number]>;
+  findManyAndCount(qm: QueryCriteria<E>, project?: QueryProject<E>): Promise<[E[], number]>;
 
   count(qm?: QuerySearch<E>): Promise<number>;
 

--- a/packages/nukak/src/type/universalQuerier.ts
+++ b/packages/nukak/src/type/universalQuerier.ts
@@ -13,7 +13,7 @@ export interface UniversalQuerier {
    * @param id the primary key value
    * @return the record
    */
-  findOneById<E, P extends QueryProject<E>>(entity: Type<E>, id: IdValue<E>, project?: P): Promise<any>;
+  findOneById<E>(entity: Type<E>, id: IdValue<E>, project?: QueryProject<E>): Promise<any>;
 
   /**
    * obtains the first record matching the given search parameters.
@@ -21,7 +21,7 @@ export interface UniversalQuerier {
    * @param qm the criteria options
    * @return the record
    */
-  findOne<E, P extends QueryProject<E>>(entity: Type<E>, qm: QueryOneCriteria<E>, project?: P): Promise<any>;
+  findOne<E>(entity: Type<E>, qm: QueryOneCriteria<E>, project?: QueryProject<E>): Promise<any>;
 
   /**
    * obtains the records matching the given search parameters.
@@ -29,7 +29,7 @@ export interface UniversalQuerier {
    * @param qm the criteria options
    * @return the records
    */
-  findMany<E, P extends QueryProject<E>>(entity: Type<E>, qm: QueryCriteria<E>, project?: P): Promise<any>;
+  findMany<E>(entity: Type<E>, qm: QueryCriteria<E>, project?: QueryProject<E>): Promise<any>;
 
   /**
    * obtains the records matching the given search parameters,
@@ -38,7 +38,7 @@ export interface UniversalQuerier {
    * @param qm the criteria options
    * @return the records and the count
    */
-  findManyAndCount<E, P extends QueryProject<E>>(entity: Type<E>, qm: QueryCriteria<E>, project?: P): Promise<any>;
+  findManyAndCount<E>(entity: Type<E>, qm: QueryCriteria<E>, project?: QueryProject<E>): Promise<any>;
 
   /**
    * counts the number of records matching the given search parameters.

--- a/yarn.lock
+++ b/yarn.lock
@@ -4076,9 +4076,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"concurrently@npm:^8.2.1":
-  version: 8.2.1
-  resolution: "concurrently@npm:8.2.1"
+"concurrently@npm:^8.2.2":
+  version: 8.2.2
+  resolution: "concurrently@npm:8.2.2"
   dependencies:
     chalk: ^4.1.2
     date-fns: ^2.30.0
@@ -4092,7 +4092,7 @@ __metadata:
   bin:
     conc: dist/bin/concurrently.js
     concurrently: dist/bin/concurrently.js
-  checksum: 216cb16d5b301cbd9c657b19430836d1686fe8fa9b9ef35ef7ac601e1a5cf6535166a3e57de446696dbd5e7e3f45d78fc70f33c5fd4bb565342cd5e752c5b069
+  checksum: 8ac774df06869773438f1bf91025180c52d5b53139bc86cf47659136c0d97461d0579c515d848d1e945d4e3e0cafe646b2ea18af8d74259b46abddcfe39b2c6c
   languageName: node
   linkType: hard
 
@@ -8264,7 +8264,7 @@ __metadata:
   resolution: "nukak-browser@workspace:packages/nukak-browser"
   dependencies:
     bunchee: ^3.9.0
-    concurrently: ^8.2.1
+    concurrently: ^8.2.2
     copyfiles: ^2.4.1
     nukak: ^0.3.1
     rimraf: ^5.0.5
@@ -9518,7 +9518,7 @@ __metadata:
     "@types/jest": ^29.5.6
     "@typescript-eslint/eslint-plugin": ^6.8.0
     "@typescript-eslint/parser": ^6.8.0
-    concurrently: ^8.2.1
+    concurrently: ^8.2.2
     coveralls: ^3.1.1
     eslint: ^8.51.0
     eslint-config-prettier: ^9.0.0


### PR DESCRIPTION
1. Remove `$group` and `$having` as they detriment type safety as currently implemented (support may be redesigned later if required).
2. Improve type safety of `$project` operator.
3. Improve type safety of `$filter` operator.
4. Remove projection operators (`$count`, `$min`, `$max`, `$min`, and `$sum`) as they detriment type safety as currently implemented. This can be done via Virtual fields instead as currently supported for better type safety.